### PR TITLE
Integrate Marked.js and Highlight.js for Markdown rendering

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,11 @@
     <title>Mistral OCR Документов</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="../static/css/main.css">
+    <!-- Marked.js via CDN -->
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <!-- highlight.js via CDN -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 </head>
 <body>
     <div class="container-fluid py-5">
@@ -160,16 +165,21 @@
                         pageTitle.textContent = `Страница ${page.index + 1}`;
                         pageDiv.appendChild(pageTitle);
 
-                        const markdownPre = document.createElement('pre');
-                        markdownPre.textContent = page.markdown;
-                        pageDiv.appendChild(markdownPre);
+                        // Используем Marked.js для рендеринга Markdown
+                        const markdownOutputDiv = document.createElement('div');
+                        markdownOutputDiv.classList.add('markdown-rendered-content');
+                        markdownOutputDiv.innerHTML = marked.parse(page.markdown); // Используем marked.parse()
+                        pageDiv.appendChild(markdownOutputDiv);
 
                         if (page.images && page.images.length) {
                             page.images.forEach(img => {
                                 const imgElem = document.createElement('img');
-                                imgElem.src = `/image/${img.path.split('\\').pop()}`;
-                                imgElem.classList.add('img-fluid', 'image-preview');
-                                pageDiv.appendChild(imgElem);
+                                // Обеспечиваем корректный путь к изображению, если он содержит обратные слеши
+                                const imageName = img.path.split(/[\\/]/).pop();
+                                imgElem.src = `/image/${imageName}`;
+                                imgElem.classList.add('img-fluid', 'image-preview', 'my-2'); // Добавлен отступ для изображений
+                                // Вставляем изображения после markdown контента страницы
+                                markdownOutputDiv.appendChild(imgElem);
                             });
                         }
 
@@ -179,6 +189,11 @@
                     // Обновление ссылок на скачивание
                     document.getElementById('download-markdown').href = `/download/markdown/${data.data.markdown_file}`;
                     document.getElementById('download-json').href = `/download/json/${data.data.json_file}`;
+
+                    // Инициализация подсветки синтаксиса
+                    document.querySelectorAll('.markdown-rendered-content pre code').forEach((block) => {
+                        hljs.highlightElement(block);
+                    });
 
                 } else {
                     errorMessage.textContent = data.message;


### PR DESCRIPTION
- Added Marked.js library to render Markdown content as HTML.
- Modified JavaScript to use Marked.js for parsing and displaying Markdown.
- Added Highlight.js library for syntax highlighting of code blocks.
- Updated JavaScript to apply syntax highlighting after Markdown rendering.
- Images are now appended within the rendered Markdown content div for better structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OCR-processed markdown content is now displayed as formatted HTML with syntax highlighting, improving readability and presentation.
* **Improvements**
  * Images are now displayed after the markdown content for each page.
  * Enhanced support for image file paths with different slash formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->